### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
-VariableTimedAction KEYWORD1
-start KEYWORD2
-stop  KEYWORD2
-toggleRunning KEYWORD2
-isRunning KEYWORD2
-updateActions KEYWORD2
+VariableTimedAction	KEYWORD1
+start	KEYWORD2
+stop	KEYWORD2
+toggleRunning	KEYWORD2
+isRunning	KEYWORD2
+updateActions	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without a tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords